### PR TITLE
Add battery status support from Telldus-api

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,7 +1,7 @@
 {
   "id": "com.telldus.live",
-  "version": "1.0.1",
-  "compatibility": ">=2.0.0",
+  "version": "1.1.0",
+  "compatibility": ">=3.0.0",
   "sdk": 2,
   "brandColor": "#C67641",
   "name": {
@@ -42,6 +42,10 @@
       {
         "name": "Bjørnar Almli",
         "email": "bjornar.almli@gmail.com"
+      },
+      {
+        "name": "Even Ambjørnrud",
+        "email": "even@ambjornrud.no"
       }
     ]
   },

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.telldus.live",
-  "version": "1.0.1",
-  "compatibility": ">=2.0.0",
+  "version": "1.1.0",
+  "compatibility": ">=3.0.0",
   "sdk": 2,
   "brandColor": "#C67641",
   "name": {
@@ -43,6 +43,10 @@
       {
         "name": "Bjørnar Almli",
         "email": "bjornar.almli@gmail.com"
+      },
+      {
+        "name": "Even Ambjørnrud",
+        "email": "even@ambjornrud.no"
       }
     ]
   },

--- a/drivers/Sensor/device.js
+++ b/drivers/Sensor/device.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseDevice = require('../../lib/BaseDevice');
+const constantsTelldus = require('../../lib/telldus-api/constants');
 
 module.exports = class SensorDevice extends BaseDevice {
 
@@ -10,18 +11,30 @@ module.exports = class SensorDevice extends BaseDevice {
                 //this.log('onSensorValue', this.getId(), sensor);
                 //this.log(`${sensor.name}`, sensor.data.map(v => `${v.name} = ${v.value}`).join(', '));
                 for (let val of sensor.data) {
+                    let measureValue = parseFloat(val.value);
                     if (val.name === 'temp') {
-                        this.updateValue('measure_temperature', sensor, val);
+                        this.updateValue('measure_temperature', sensor, measureValue);
                     } else if (val.name === 'humidity') {
-                        this.updateValue('measure_humidity', sensor, val);
+                        this.updateValue('measure_humidity', sensor, measureValue);
                     } else if (val.name === 'watt') {
                         if (val.unit === 'kWh') {
-                            this.updateValue('meter_power', sensor, val);
+                            this.updateValue('meter_power', sensor, measureValue);
                         } else if (val.unit === 'W') {
-                            this.updateValue('measure_power', sensor, val);
+                            this.updateValue('measure_power', sensor, measureValue);
                         } else if (val.unit === 'V') {
-                            this.updateValue('measure_voltage', sensor, val);
+                            this.updateValue('measure_voltage', sensor, measureValue);
                         }
+                    }
+                }
+                if (sensor.battery) {
+                    //this.log(`${sensor.id} ${sensor.name} battery =`, sensor.battery);
+                    let batteryValue = parseFloat(sensor.battery);
+                    if (batteryValue == constantsTelldus.BATTERY_STATUS.ok) {
+                        this.updateValue('alarm_battery', sensor, false);
+                    } else if (batteryValue == constantsTelldus.BATTERY_STATUS.low) {
+                        this.updateValue('alarm_battery', sensor, true);
+                    } else if (batteryValue >= 0 && batteryValue <= 100) {
+                        this.updateValue('measure_battery', sensor, batteryValue);
                     }
                 }
             }
@@ -30,14 +43,14 @@ module.exports = class SensorDevice extends BaseDevice {
         }
     }
 
-    updateValue(capability, sensor, val) {
-        if (this.hasCapability(capability)) {
-            const value = parseFloat(val.value);
-            if (value !== this.getCapabilityValue(capability)) {
-                this.setCapabilityValue(capability, value).catch(err => this.log(`error setting ${capability} capability`, err));
-                this.log(`${sensor.name} => ${value} UPDATED`);
-            }
+    updateValue(capability, sensor, value) {
+        if (!this.hasCapability(capability)) {
+            this.addCapability(capability);
+        }
+
+        if (value !== this.getCapabilityValue(capability)) {
+            this.setCapabilityValue(capability, value).catch(err => this.log(`error setting ${capability} capability`, err));
+            this.log(`${sensor.name} ${capability} => ${value} UPDATED`);
         }
     }
-
 };

--- a/lib/telldus-api/constants.js
+++ b/lib/telldus-api/constants.js
@@ -11,8 +11,15 @@ const commands = {
     up: 0x0080, // 128
     down: 0x0100, // 256
     stop: 0x0200, // 512
+    rgb: 0x0400, // 1024
+    thermostat: 0x0800, // 2048
 };
 
+const BATTERY_STATUS = {
+    ok: 253,
+    unknown: 254, //battery status unknown (not reported by this sensor type, or not decoded)
+    low: 255
+};
 
 const DEVICE_TYPES = {
     device_alt: { description: 'Unknown_other', id: '00000000-0001-1000-2005-ACCA54000000' },
@@ -46,5 +53,6 @@ for (const [key, value] of Object.entries(DEVICE_TYPES)) {
 module.exports = {
     commands: commands,
     DEVICE_TYPES: DEVICE_TYPES,
-    DEVICE_TYPES_INVERTED: DEVICE_TYPES_INVERTED
+    DEVICE_TYPES_INVERTED: DEVICE_TYPES_INVERTED,
+    BATTERY_STATUS: BATTERY_STATUS
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,45 @@
 {
   "name": "com.telldus.live",
   "version": "1.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-fetch": "^2.6.0",
+        "oauth-1.0a": "^2.2.2"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/oauth-1.0a": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+      "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ=="
+    }
+  },
   "dependencies": {
     "debug": {
       "version": "3.2.7",


### PR DESCRIPTION
Implemented:
 - onPair: Add new capabilities (alarm_battery / measure_battery) when sensor has this info.
 - onSensor-readings: Dynamically add these capabilities on already paired devices.
 - Bump minor-version as function addCapability() is added since 3.0.0

Info about Telldus battery status from sensors:
https://developer.telldus.com/blog/2015/02/19/introducing-battery-status

Homey Energy and batteries property introduced in Homey firmware v3.0.0:
https://homey.app/en-au/blog/developers-homey-energy/